### PR TITLE
Update C# template with Dispose pattern implementation

### DIFF
--- a/content/dotnet-template-azure-iot-edge-module/CSharp/Program.cs
+++ b/content/dotnet-template-azure-iot-edge-module/CSharp/Program.cs
@@ -75,13 +75,16 @@ namespace SampleModule
 
             if (!string.IsNullOrEmpty(messageString))
             {
-                var pipeMessage = new Message(messageBytes);
-                foreach (var prop in message.Properties)
+                using (var pipeMessage = new Message(messageBytes))
                 {
-                    pipeMessage.Properties.Add(prop.Key, prop.Value);
+                    foreach (var prop in message.Properties)
+                    {
+                        pipeMessage.Properties.Add(prop.Key, prop.Value);
+                    }
+                    await moduleClient.SendEventAsync("output1", pipeMessage);
+                
+                    Console.WriteLine("Received message sent");
                 }
-                await moduleClient.SendEventAsync("output1", pipeMessage);
-                Console.WriteLine("Received message sent");
             }
             return MessageResponse.Completed;
         }


### PR DESCRIPTION
As discussed in https://github.com/microsoft/vscode-azure-iot-edge/issues/503

In the C# module template and the C# function template, a message is constructed:

var pipeMessage = new Message(messageBytes);

The Message class implements the Dispose method. The Message class must follow the Dispose pattern to ensure it's disposed in all paths.

With 'using()' we can enforce the Dispose pattern.

This is also in sync with eg. the https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-csharp-module documentation.