### PR TITLE
Install missing curl for debug dockerfiles

### DIFF
--- a/content/dotnet-template-azure-iot-edge-module/CSharp/Dockerfile.amd64.debug
+++ b/content/dotnet-template-azure-iot-edge-module/CSharp/Dockerfile.amd64.debug
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends unzip procps && \
+    apt-get install -y --no-install-recommends unzip procps curl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash moduleuser

--- a/content/dotnet-template-azure-iot-edge-module/CSharp/Dockerfile.arm32v7.debug
+++ b/content/dotnet-template-azure-iot-edge-module/CSharp/Dockerfile.arm32v7.debug
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim-arm32v7 AS base
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends unzip procps && \
+    apt-get install -y --no-install-recommends unzip procps curl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash moduleuser

--- a/content/dotnet-template-azure-iot-edge-module/CSharp/Dockerfile.arm64v8.debug
+++ b/content/dotnet-template-azure-iot-edge-module/CSharp/Dockerfile.arm64v8.debug
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim-arm64v8 AS base
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends unzip procps && \
+    apt-get install -y --no-install-recommends unzip procps curl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash moduleuser


### PR DESCRIPTION
To use `RUN curl` the layer must have `curl` installed first. When piping the result of a `curl` to `bash`, any errors from the first part is silently dropped, and in the end you produce a container that doesn't have the advertised feature.
